### PR TITLE
Readded the CNAME file as it is necessary but not in the root. Instea…

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-augustroosi.ee

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+augustroosi.ee


### PR DESCRIPTION
…d the CNAME file is placed in the public folder as in build all the public folder files are copied to build root. Build root is the place where the CNAME is needed.